### PR TITLE
switch to using new Base.Iterators module on v0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.4
 Compat
-Iterators

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -3,7 +3,11 @@ VERSION >= v"0.4.0-dev+6641" && __precompile__()
 module Showoff
 
 using Compat
-using Iterators: drop
+if VERSION >= v"0.6.0-dev.1015"
+    import Base.Iterators: drop
+else
+    import Iterators: drop
+end
 
 export showoff
 

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -5,8 +5,6 @@ module Showoff
 using Compat
 if VERSION >= v"0.6.0-dev.1015"
     import Base.Iterators: drop
-else
-    import Iterators: drop
 end
 
 export showoff


### PR DESCRIPTION
fixes deprecation warnings on v0.6. see JuliaLang/julia#18839 for more
details.