### PR TITLE
Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ julia:
   - nightly
 notifications:
   email: false
+after_success:
+  - julia -e 'cd(Pkg.dir("Showoff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Showoff
 
-[![Build
-Status](https://travis-ci.org/JuliaGraphics/Showoff.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphics/Showoff.jl)
+[![Showoff](http://pkg.julialang.org/badges/Showoff_0.5.svg)](http://pkg.julialang.org/?pkg=Showoff)
+[![Showoff](http://pkg.julialang.org/badges/Showoff_0.6.svg)](http://pkg.julialang.org/?pkg=Showoff)
+[![Build Status](https://travis-ci.org/JuliaGraphics/Showoff.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphics/Showoff.jl)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaGraphics/Showoff.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaGraphics/Showoff.jl?branch=master)
 
 Showoff provides an interface for consistently formatting an array of n things,
 e.g. numbers, dates, unitful values. It's used in Gadfly to
@@ -58,4 +60,4 @@ trailing the `.`, and look nice when right-aligned.
 
 When no specialized `showoff` is defined, it falls back on the `show` function.
 
-
+This package was originally written by [Daniel C. Jones](https://github.com/dcjones).

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.9.5
+Compat 0.18.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,48 @@
 using Showoff
 using Base.Test
 
-# write your own tests here
-@test 1 == 1
+@testset "Internals" begin
+    @test Showoff.@grisu_ccall(1, 2, 3) === nothing
+    @test Showoff.grisu(1.0, Base.Grisu.SHORTEST, 2) == (1, 1, false, Base.Grisu.DIGITS)
+
+    let x = [1.0, Inf, 2.0, NaN]
+        @test Showoff.concrete_minimum(x) == 1.0
+        @test Showoff.concrete_maximum(x) == 2.0
+    end
+
+    @test_throws ArgumentError Showoff.concrete_minimum([])
+    @test_throws ArgumentError Showoff.concrete_maximum([])
+
+    let x = [1.12345, 4.5678]
+        @test Showoff.plain_precision_heuristic(x) == 5
+        @test Showoff.scientific_precision_heuristic(x) == 6
+    end
+end
+
+@testset "Formatting" begin
+    @test Showoff.format_fixed(-10.0, 0) == "-10"
+    @test Showoff.format_fixed(0.012345, 3) == "0.012"
+    @test Showoff.format_fixed(Inf, 1) == "∞"
+    @test Showoff.format_fixed(-Inf, 1) == "-∞"
+    @test Showoff.format_fixed(NaN, 1) == "NaN"
+    @test Showoff.format_fixed_scientific(0.0, 1, false) == "0"
+    @test Showoff.format_fixed_scientific(Inf, 1, false) == "∞"
+    @test Showoff.format_fixed_scientific(-Inf, 1, false) == "-∞"
+    @test Showoff.format_fixed_scientific(NaN, 1, false) == "NaN"
+    @test Showoff.format_fixed_scientific(0.012345678, 4, true) == "12.34568×10⁻³"
+    @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.234568×10⁻²"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.000×10¹"
+end
+
+@testset "Showoff" begin
+    x = [1.12345, 4.5678]
+    @test showoff(x) == ["1.12345", "4.56780"]
+    @test showoff([0.0, 50000.0]) == ["0", "5×10⁴"]
+    @test showoff(x, :plain) == ["1.12345", "4.56780"]
+    @test showoff(x, :scientific) == ["1.12345×10⁰", "4.56780×10⁰"]
+    @test showoff(x, :engineering) == ["1.12345×10⁰", "4.56780×10⁰"]
+    @test showoff([Dates.DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
+    @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
+    @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
+    @test_throws ArgumentError showoff([Inf, Inf, NaN])
+end


### PR DESCRIPTION
This PR addresses a few things. First, it cleans up some of the version conditional logic in the internals, which is no longer necessary since this package now requires Julia 0.5 at a minimum. It also uses concrete types for array element types when those types are known (primarily `AbstractString` -> `String`). Next, status badges and a hat tip to dcjones. And finally, tests!

Fixes #5 