### PR TITLE
handle non-finite input gracefully

### DIFF
--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -103,7 +103,7 @@ function showoff{T <: AbstractFloat}(xs::AbstractArray{T}, style=:auto)
     x_max = Float64(Float32(x_max))
 
     if !isfinite(x_min) || !isfinite(x_max)
-        throw(ArgumentError("At least one finite value must be provided to formatter."))
+        return invoke(showoff,Tuple{AbstractArray,Symbol},xs,:none)
     end
 
     if style == :auto

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,5 +44,5 @@ end
     @test showoff([Dates.DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
     @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
     @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
-    @test_throws ArgumentError showoff([Inf, Inf, NaN])
+    @test showoff([Inf, Inf, NaN]) == ["Inf", "Inf", "NaN"]
 end


### PR DESCRIPTION
Throwing on well-formed edge cases is obnoxious. Let's do what the (paltry) documentation says instead.