### PR TITLE
Updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 os:
   - linux
-  - osx
+#  - osx
 julia:
   - 0.6
   - nightly

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Showoff
 
-[![Showoff](http://pkg.julialang.org/badges/Showoff_0.5.svg)](http://pkg.julialang.org/?pkg=Showoff)
 [![Showoff](http://pkg.julialang.org/badges/Showoff_0.6.svg)](http://pkg.julialang.org/?pkg=Showoff)
+[![Showoff](http://pkg.julialang.org/badges/Showoff_0.7.svg)](http://pkg.julialang.org/?pkg=Showoff)
 [![Build Status](https://travis-ci.org/JuliaGraphics/Showoff.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphics/Showoff.jl)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaGraphics/Showoff.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaGraphics/Showoff.jl?branch=master)
 
@@ -16,9 +16,9 @@ If you want your type to look nice when plotted, just define a `showoff`
 function. Here's an example.
 
 ```julia
-import Showoff
+using Showoff
 
-immutable Percent
+struct Percent
     value::Float64
 end
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-Compat 0.18.0
+julia 0.6
+Compat 0.59.0

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -3,7 +3,7 @@ __precompile__()
 module Showoff
 
 using Compat
-import Compat.Iterators: drop
+using Compat.Dates
 
 export showoff
 
@@ -21,7 +21,7 @@ end
 
 # Fallback
 function showoff(xs::AbstractArray, style=:none)
-    result = Vector{String}(length(xs))
+    result = Vector{String}(undef, length(xs))
     buf = IOBuffer()
     for (i, x) in enumerate(xs)
         show(buf, x)
@@ -78,7 +78,7 @@ function concrete_maximum(xs)
 end
 
 
-function plain_precision_heuristic{T <: AbstractFloat}(xs::AbstractArray{T})
+function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = filter(isfinite, xs)
     precision = 0
     for y in ys
@@ -89,14 +89,14 @@ function plain_precision_heuristic{T <: AbstractFloat}(xs::AbstractArray{T})
 end
 
 
-function scientific_precision_heuristic{T <: AbstractFloat}(xs::AbstractArray{T})
+function scientific_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = [x == 0.0 ? 0.0 : x / 10.0^floor(log10(abs(x)))
           for x in xs if isfinite(x)]
     return plain_precision_heuristic(ys) + 1
 end
 
 
-function showoff{T <: AbstractFloat}(xs::AbstractArray{T}, style=:auto)
+function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto)
     x_min = concrete_minimum(xs)
     x_max = concrete_maximum(xs)
     x_min = Float64(Float32(x_min))
@@ -262,7 +262,7 @@ function format_fixed_scientific(x::AbstractFloat, precision::Integer,
 end
 
 
-function showoff{T <: (Union{Date, DateTime})}(ds::AbstractArray{T}, style=:none)
+function showoff(ds::AbstractArray{T}, style=:none) where T<:Union{Date,DateTime}
     years = Set()
     months = Set()
     days = Set()
@@ -311,7 +311,7 @@ function showoff{T <: (Union{Date, DateTime})}(ds::AbstractArray{T}, style=:none
         first_label_format = f1
     end
 
-    labels = Vector{String}(length(ds))
+    labels = Vector{String}(undef, length(ds))
     labels[1] = Dates.format(ds[1], first_label_format)
     d_last = ds[1]
     for (i, d) in enumerate(ds[2:end])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Showoff
 using Compat
 using Compat.Test
+using Compat.Dates
 
 @testset "Internals" begin
     @test Showoff.@grisu_ccall(1, 2, 3) === nothing
@@ -42,7 +43,7 @@ end
     @test showoff(x, :plain) == ["1.12345", "4.56780"]
     @test showoff(x, :scientific) == ["1.12345×10⁰", "4.56780×10⁰"]
     @test showoff(x, :engineering) == ["1.12345×10⁰", "4.56780×10⁰"]
-    @test showoff([Dates.DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
+    @test showoff([DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
     @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
     @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
     @test_throws ArgumentError showoff([Inf, Inf, NaN])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Showoff
-using Base.Test
+using Compat
+using Compat.Test
 
 @testset "Internals" begin
     @test Showoff.@grisu_ccall(1, 2, 3) === nothing


### PR DESCRIPTION
Drops support for 0.5. Supersedes #10.