### PR TITLE
Allow big floats (fix #13)

### DIFF
--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -82,7 +82,7 @@ function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = filter(isfinite, xs)
     precision = 0
     for y in ys
-        len, point, neg, digits = grisu(convert(Float32, y), Base.Grisu.SHORTEST, 0)
+        len, point, neg, digits = grisu(y, Base.Grisu.SHORTEST, 0)
         precision = max(precision, len - point)
     end
     return max(precision, 0)
@@ -99,8 +99,8 @@ end
 function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto)
     x_min = concrete_minimum(xs)
     x_max = concrete_maximum(xs)
-    x_min = Float64(Float32(x_min))
-    x_max = Float64(Float32(x_max))
+    x_min = Float64(x_min)
+    x_max = Float64(x_max)
 
     if !isfinite(x_min) || !isfinite(x_max)
         throw(ArgumentError("At least one finite value must be provided to formatter."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ end
     @test showoff(x, :engineering) == ["1.12345×10⁰", "4.56780×10⁰"]
     @test showoff([DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
     @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
+    @test showoff([1, 1e39]) == ["1×10⁰", "1×10³⁹"]
     @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
     @test_throws ArgumentError showoff([Inf, Inf, NaN])
 end


### PR DESCRIPTION
This avoids the internal conversion to Float32, as discussed in #13.
Changes
```julia
julia> showoff([1, 1e39])
ERROR: ArgumentError: At least one finite value must be provided to formatter.
Stacktrace:
 [1] showoff(::Array{Float64,1}, ::Symbol) at /home/daniel/.julia/dev/Showoff/src/Showoff.jl:106
 [2] showoff(::Array{Float64,1}) at /home/daniel/.julia/dev/Showoff/src/Showoff.jl:100
 [3] top-level scope at none:0
```
to
```julia
julia> showoff([1, 1e39])
2-element Array{String,1}:
 "1×10⁰" 
 "1×10³⁹"
```