### PR TITLE
Plain precision (fix #16)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Showoff"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 author = ["Daniel C. Jones (@dcjones)"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
-julia = "≥ 1"
+julia = "1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -81,7 +81,7 @@ function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = filter(isfinite, xs)
     precision = 0
     for y in ys
-        len, point, neg, digits = grisu(y, Base.Grisu.SHORTEST, 0)
+        len, point, neg, digits = grisu(convert(Float32, y), Base.Grisu.SHORTEST, 0)
         precision = max(precision, len - point)
     end
     return max(precision, 0)


### PR DESCRIPTION
My recent removal of the Float32 conversion (#15) caused a display issue in Plots:
```julia
using Plots
plot([0.1, 0.2])
```
![plain_precision](https://user-images.githubusercontent.com/16589944/60394427-6d83e880-9b24-11e9-9327-fbff20c89105.png)

This PR fixes it, but still allows to plot large numbers (by only adding the Float32 conversion in the plain_precision_heuristic).

Furthermore, I upped the version for a quick release and changed the julia compat as Fredrik Ekre suggested.

cc: @SimonDanisch 