### PR TITLE
use Grisu package on julia >= 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 #  - osx
 julia:
   - 1.0
-  - 1.1
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Grisu = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 
 [compat]
 julia = "1"
+Grisu = "1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Showoff"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 author = ["Daniel C. Jones (@dcjones)"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -4,6 +4,12 @@ module Showoff
 
 using Dates
 
+if isdefined(Base, :Grisu)
+    import Base.Grisu
+else
+    import Grisu
+end
+
 export showoff
 
 
@@ -14,7 +20,7 @@ end
 
 
 function grisu(v::AbstractFloat, mode, requested_digits)
-    return tuple(Base.Grisu.grisu(v, mode, requested_digits)..., Base.Grisu.DIGITS)
+    return tuple(Grisu.grisu(v, mode, requested_digits)..., Grisu.DIGITS)
 end
 
 
@@ -81,7 +87,7 @@ function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = filter(isfinite, xs)
     precision = 0
     for y in ys
-        len, point, neg, digits = grisu(convert(Float32, y), Base.Grisu.SHORTEST, 0)
+        len, point, neg, digits = grisu(convert(Float32, y), Grisu.SHORTEST, 0)
         precision = max(precision, len - point)
     end
     return max(precision, 0)
@@ -143,7 +149,7 @@ function format_fixed(x::AbstractFloat, precision::Integer)
         return "NaN"
     end
 
-    len, point, neg, digits = grisu(x, Base.Grisu.FIXED, precision)
+    len, point, neg, digits = grisu(x, Grisu.FIXED, precision)
 
     buf = IOBuffer()
     if x < 0
@@ -212,7 +218,7 @@ function format_fixed_scientific(x::AbstractFloat, precision::Integer,
         grisu_precision = precision
     end
 
-    len, point, neg, digits = grisu((x / 10.0^mag), Base.Grisu.FIXED, grisu_precision)
+    len, point, neg, digits = grisu((x / 10.0^mag), Grisu.FIXED, grisu_precision)
     point += mag
 
     @assert len > 0


### PR DESCRIPTION
uses https://github.com/JuliaAttic/Grisu.jl instead of the removed Base.Grisu on julia 1.6