### PR TITLE
added support for engineering notation

### DIFF
--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -163,6 +163,11 @@ function format_fixed_scientific(x::AbstractFloat, precision::Integer,
     end
     leading_index = findfirst(c -> '1' <= c <= '9', power)
 
+    if isnothing(leading_index)
+        print(buf, superscript_numerals[1])
+        return String(take!(buf))
+    end
+
     for (i,c) in enumerate(power[leading_index:end])
         if c == '-'
             print(buf, '⁻')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,8 @@
 using Showoff
 using Test
 using Dates
-if isdefined(Base, :Grisu)
-    const Grisu = Base.Grisu
-else
-    import Grisu
-end
 
 @testset "Internals" begin
-    @test Showoff.@grisu_ccall(1, 2, 3) === nothing
-    @test Showoff.grisu(1.0, Grisu.SHORTEST, 2) == (1, 1, false, Grisu.DIGITS)
-
     let x = [1.0, Inf, 2.0, NaN]
         @test Showoff.concrete_minimum(x) == 1.0
         @test Showoff.concrete_maximum(x) == 2.0
@@ -36,8 +28,9 @@ end
     @test Showoff.format_fixed_scientific(-Inf, 1, false) == "-∞"
     @test Showoff.format_fixed_scientific(NaN, 1, false) == "NaN"
     @test Showoff.format_fixed_scientific(0.012345678, 4, true) == "12.34568×10⁻³"
-    @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.234568×10⁻²"
-    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.000×10¹"
+    @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.2346×10⁻²"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
+    @test Showoff.format_fixed_scientific(-2.99999999999999956E-16, 2, false) == "-3.00×10⁻¹⁶"
 end
 
 @testset "Showoff" begin


### PR DESCRIPTION
@timholy I fixed the engineering notation, although it required conversion back to Ints, I believe it is okay for such an exotic need, plus we can add support for more notation with decoupled functions like `plotly` notation I always wanted to see:
```
1e6 = 1M
1.1e9 = 1G
1.1e-3 = 1milli 
```