### PR TITLE
Migrate to Ryu on supported Julia versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ julia = "1"
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [targets]
-test = ["Dates", "Test"]
+test = ["Dates", "Test", "Printf"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Showoff"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 author = ["Daniel C. Jones (@dcjones)"]
-version = "0.3.2"
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -2,10 +2,10 @@ module Showoff
 
 using Dates
 
-if isdefined(Base, :Grisu)
-    include("grisu.jl")
-else
+if isdefined(Base, :Ryu)
     include("ryu.jl")
+else
+    include("grisu.jl")
 end
 
 export showoff

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -74,7 +74,7 @@ function concrete_maximum(xs)
 end
 
 function scientific_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
-    ys = [x == 0.0 ? 0.0 : x / 10.0^floor(log10(abs(x)))
+    ys = [x == 0.0 ? 0.0 : round(10.0 ^ (z = log10(abs(Float64(x))); z - floor(z)); sigdigits=15)
           for x in xs if isfinite(x)]
     return plain_precision_heuristic(ys) + 1
 end

--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -1,28 +1,19 @@
-__precompile__()
-
 module Showoff
 
 using Dates
 
 if isdefined(Base, :Grisu)
-    import Base.Grisu
+    include("grisu.jl")
 else
-    import Grisu
+    include("ryu.jl")
 end
 
 export showoff
-
 
 # suppress compile errors when there isn't a grisu_ccall macro
 macro grisu_ccall(x, mode, ndigits)
     quote end
 end
-
-
-function grisu(v::AbstractFloat, mode, requested_digits)
-    return tuple(Grisu.grisu(v, mode, requested_digits)..., Grisu.DIGITS)
-end
-
 
 # Fallback
 function showoff(xs::AbstractArray, style=:none)
@@ -82,18 +73,6 @@ function concrete_maximum(xs)
     return x_max
 end
 
-
-function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
-    ys = filter(isfinite, xs)
-    precision = 0
-    for y in ys
-        len, point, neg, digits = grisu(convert(Float32, y), Grisu.SHORTEST, 0)
-        precision = max(precision, len - point)
-    end
-    return max(precision, 0)
-end
-
-
 function scientific_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
     ys = [x == 0.0 ? 0.0 : x / 10.0^floor(log10(abs(x)))
           for x in xs if isfinite(x)]
@@ -135,132 +114,7 @@ function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto)
     end
 end
 
-
-# Print a floating point number at fixed precision. Pretty much equivalent to
-# @sprintf("%0.$(precision)f", x), without the macro issues.
-function format_fixed(x::AbstractFloat, precision::Integer)
-    @assert precision >= 0
-
-    if x == Inf
-        return "∞"
-    elseif x == -Inf
-        return "-∞"
-    elseif isnan(x)
-        return "NaN"
-    end
-
-    len, point, neg, digits = grisu(x, Grisu.FIXED, precision)
-
-    buf = IOBuffer()
-    if x < 0
-        print(buf, '-')
-    end
-
-    for c in digits[1:min(point, len)]
-        print(buf, convert(Char, c))
-    end
-
-    if point > len
-        for _ in len:point-1
-            print(buf, '0')
-        end
-    elseif point < len
-        if point <= 0
-            print(buf, '0')
-        end
-        print(buf, '.')
-        if point < 0
-            for _ in 1:-point
-                print(buf, '0')
-            end
-            for c in digits[1:len]
-                print(buf, convert(Char, c))
-            end
-        else
-            for c in digits[point+1:len]
-                print(buf, convert(Char, c))
-            end
-        end
-    end
-
-    trailing_zeros = precision - max(0, len - point)
-    if trailing_zeros > 0 && point >= len
-        print(buf, '.')
-    end
-
-    for _ in 1:trailing_zeros
-        print(buf, '0')
-    end
-
-    String(take!(buf))
-end
-
 const superscript_numerals = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
-
-# Print a floating point number in scientific notation at fixed precision. Sort of equivalent
-# to @sprintf("%0.$(precision)e", x), but prettier printing.
-function format_fixed_scientific(x::AbstractFloat, precision::Integer,
-                                 engineering::Bool)
-    if x == 0.0
-        return "0"
-    elseif x == Inf
-        return "∞"
-    elseif x == -Inf
-        return "-∞"
-    elseif isnan(x)
-        return "NaN"
-    end
-
-    mag = floor(Int, log10(abs(x)))
-    grisu_precision = precision
-
-    len, point, neg, digits = grisu((x / 10.0^mag), Grisu.FIXED, grisu_precision)
-    point += mag
-
-    @assert len > 0
-
-    buf = IOBuffer()
-    if x < 0
-        print(buf, '-')
-    end
-
-    print(buf, convert(Char, digits[1]))
-    nextdigit = 2
-    if engineering
-        while (point - 1) % 3 != 0
-            if nextdigit <= len
-                print(buf, convert(Char, digits[nextdigit]))
-            else
-                print(buf, '0')
-            end
-            nextdigit += 1
-            point -= 1
-        end
-    end
-
-    if precision > 1
-        print(buf, '.')
-    end
-
-    for i in nextdigit:len
-        print(buf, convert(Char, digits[i]))
-    end
-
-    for i in (len+1):precision
-        print(buf, '0')
-    end
-
-    print(buf, "×10")
-    for c in string(point - 1)
-        if '0' <= c <= '9'
-            print(buf, superscript_numerals[c - '0' + 1])
-        elseif c == '-'
-            print(buf, '⁻')
-        end
-    end
-
-    return String(take!(buf))
-end
 
 
 function showoff(ds::AbstractArray{T}, style=:none) where T<:Union{Date,DateTime}

--- a/src/grisu.jl
+++ b/src/grisu.jl
@@ -1,0 +1,146 @@
+# This is used on Julia version that have the Base.Grisu module
+
+import Base.Grisu
+
+function grisu(v::AbstractFloat, mode, requested_digits)
+    return tuple(Grisu.grisu(v, mode, requested_digits)..., Grisu.DIGITS)
+end
+
+function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
+    ys = filter(isfinite, xs)
+    precision = 0
+    for y in ys
+        len, point, neg, digits = grisu(convert(Float32, y), Grisu.SHORTEST, 0)
+        precision = max(precision, len - point)
+    end
+    return max(precision, 0)
+end
+
+# Print a floating point number at fixed precision. Pretty much equivalent to
+# @sprintf("%0.$(precision)f", x), without the macro issues.
+function format_fixed(x::AbstractFloat, precision::Integer)
+    @assert precision >= 0
+
+    if x == Inf
+        return "∞"
+    elseif x == -Inf
+        return "-∞"
+    elseif isnan(x)
+        return "NaN"
+    end
+
+    len, point, neg, digits = grisu(x, Grisu.FIXED, precision)
+
+    buf = IOBuffer()
+    if x < 0
+        print(buf, '-')
+    end
+
+    for c in digits[1:min(point, len)]
+        print(buf, convert(Char, c))
+    end
+
+    if point > len
+        for _ in len:point-1
+            print(buf, '0')
+        end
+    elseif point < len
+        if point <= 0
+            print(buf, '0')
+        end
+        print(buf, '.')
+        if point < 0
+            for _ in 1:-point
+                print(buf, '0')
+            end
+            for c in digits[1:len]
+                print(buf, convert(Char, c))
+            end
+        else
+            for c in digits[point+1:len]
+                print(buf, convert(Char, c))
+            end
+        end
+    end
+
+    trailing_zeros = precision - max(0, len - point)
+    if trailing_zeros > 0 && point >= len
+        print(buf, '.')
+    end
+
+    for _ in 1:trailing_zeros
+        print(buf, '0')
+    end
+
+    String(take!(buf))
+end
+
+# Print a floating point number in scientific notation at fixed precision. Sort of equivalent
+# to @sprintf("%0.$(precision)e", x), but prettier printing.
+function format_fixed_scientific(x::AbstractFloat, precision::Integer,
+                                 engineering::Bool)
+    if x == 0.0
+        return "0"
+    elseif x == Inf
+        return "∞"
+    elseif x == -Inf
+        return "-∞"
+    elseif isnan(x)
+        return "NaN"
+    end
+
+    mag = floor(Int, log10(abs(x)))
+    if mag < 0
+        grisu_precision = precision + abs(round(Int, mag))
+    else
+        grisu_precision = precision
+    end
+
+    len, point, neg, digits = grisu((x / 10.0^mag), Grisu.FIXED, grisu_precision)
+    point += mag
+
+    @assert len > 0
+
+    buf = IOBuffer()
+    if x < 0
+        print(buf, '-')
+    end
+
+    print(buf, convert(Char, digits[1]))
+    nextdigit = 2
+    if engineering
+        while (point - 1) % 3 != 0
+            if nextdigit <= len
+                print(buf, convert(Char, digits[nextdigit]))
+            else
+                print(buf, '0')
+            end
+            nextdigit += 1
+            point -= 1
+        end
+    end
+
+    if precision > 1
+        print(buf, '.')
+    end
+
+    for i in nextdigit:len
+        print(buf, convert(Char, digits[i]))
+    end
+
+    for i in (len+1):precision
+        print(buf, '0')
+    end
+
+    print(buf, "×10")
+    for c in string(point - 1)
+        if '0' <= c <= '9'
+            print(buf, superscript_numerals[c - '0' + 1])
+        elseif c == '-'
+            print(buf, '⁻')
+        end
+    end
+
+    return String(take!(buf))
+end
+

--- a/src/grisu.jl
+++ b/src/grisu.jl
@@ -90,11 +90,7 @@ function format_fixed_scientific(x::AbstractFloat, precision::Integer,
     end
 
     mag = floor(Int, log10(abs(x)))
-    if mag < 0
-        grisu_precision = precision + abs(round(Int, mag))
-    else
-        grisu_precision = precision
-    end
+    grisu_precision = precision
 
     len, point, neg, digits = grisu((x / 10.0^mag), Grisu.FIXED, grisu_precision)
     point += mag

--- a/src/ryu.jl
+++ b/src/ryu.jl
@@ -1,0 +1,79 @@
+# This is used on Julia version that have the Base.Ryu module.
+
+using Base.Ryu
+
+function plain_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
+    ys = filter(isfinite, xs)
+    precision = 0
+    for y in ys
+        b, e10 = Ryu.reduce_shortest(convert(Float32, y))
+        precision = max(precision, -e10)
+    end
+    return max(precision, 0)
+end
+
+# Print a floating point number at fixed precision. Pretty much equivalent to
+# @sprintf("%0.$(precision)f", x), without the macro issues.
+function format_fixed(x::AbstractFloat, precision::Integer)
+    @assert precision >= 0
+
+    if x == Inf
+        return "∞"
+    elseif x == -Inf
+        return "-∞"
+    elseif isnan(x)
+        return "NaN"
+    end
+
+    return Ryu.writefixed(x, precision)
+end
+
+# Print a floating point number in scientific notation at fixed precision. Sort of equivalent
+# to @sprintf("%0.$(precision)e", x), but prettier printing.
+function format_fixed_scientific(x::AbstractFloat, precision::Integer,
+                                 engineering::Bool)
+    if iszero(x)
+        return "0"
+    elseif isinf(x)
+        return signbit(x) ? "-∞" : "∞"
+    elseif isnan(x)
+        return "NaN"
+    end
+
+    if engineering
+        b, e10 = Ryu.reduce_shortest(convert(Float32, x))
+        d, r = divrem(e10, 3)
+        if d < 0 &&
+            d += sign(r)
+
+    end
+    ryustr = Ryu.writeexp(x, precision)
+    @show x ryustr
+
+    # Rewrite the exponent
+    buf = IOBuffer()
+    ret = iterate(ryustr)
+    while ret !== nothing
+        c, state = ret
+        c === 'e' && break
+        print(buf, c)
+        ret = iterate(ryustr, state)
+    end
+    if ret !== nothing
+        print(buf, "×10")
+        _, state = ret
+        ret = iterate(ryustr, state)
+        while ret !== nothing
+            c, state = ret
+            if '0' <= c <= '9'
+                print(buf, superscript_numerals[c - '0' + 1])
+            elseif c == '-'
+                print(buf, '⁻')
+            end
+            ret = iterate(ryustr, state)
+        end
+    end
+
+    return String(take!(buf))
+end
+

--- a/src/ryu.jl
+++ b/src/ryu.jl
@@ -103,11 +103,12 @@ function get_engineering_string(x::AbstractFloat, precision::Integer)
     end
 
     buf = IOBuffer()
+    negative_base_compensation = base_digits[1] == '-' ? 1 : 0
     for i in eachindex(base_digits)
         if base_digits[i] != '.'
             print(buf, base_digits[i])
         end
-        if i == 2 + indices_to_move
+        if i == 2 + indices_to_move + negative_base_compensation
             print(buf, '.')
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Showoff
 using Test
 using Dates
+using Printf
 
 @testset "Internals" begin
     @test Showoff.@grisu_ccall(1, 2, 3) === nothing
@@ -34,20 +35,23 @@ end
     @test Showoff.format_fixed_scientific(NaN, 1, false) == "NaN"
     @test Showoff.format_fixed_scientific(0.012345678, 4, true) == "12.346×10⁻³"
     @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.2346×10⁻²"
-    @test Showoff.format_fixed_scientific(2.99999999999999956E-16, 2, false) == "3.0×10⁻¹⁶"
-    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.000×10¹"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false)[1:end-5] == @sprintf("%0.4e", -10.0)[1:end-4]
+    @test Showoff.format_fixed_scientific(1.23456e7, 3, false)[1:end-5] == @sprintf("%0.3e", 1.23456e7)[1:end-4]
+    @test Showoff.format_fixed_scientific(2.99999999999999956E-16, 2, false) == "3.00×10⁻¹⁶"
 end
 
 @testset "Showoff" begin
     x = [1.12345, 4.5678]
     @test showoff(x) == ["1.12345", "4.56780"]
-    @test showoff([0.0, 50000.0]) == ["0", "5×10⁴"]
+    @test showoff([0.0, 50000.0]) == ["0", "5.0×10⁴"]
     @test showoff(x, :plain) == ["1.12345", "4.56780"]
-    @test showoff(x, :scientific) == ["1.12345×10⁰", "4.56780×10⁰"]
-    @test showoff(x, :engineering) == ["1.12345×10⁰", "4.56780×10⁰"]
+    @test showoff(x, :scientific) == ["1.123450×10⁰", "4.567800×10⁰"]
+    @test showoff(x, :engineering) == ["1.123450×10⁰", "4.567800×10⁰"]
     @test showoff([DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
     @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
-    @test showoff([1, 1e39]) == ["1×10⁰", "1×10³⁹"]
+    @test showoff([1, 1e39]) == ["1.0×10⁰", "1.0×10³⁹"]
     @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
     @test showoff([Inf, Inf, NaN]) == ["Inf", "Inf", "NaN"]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 using Dates
 using Printf
 
+const drops0s = !isdefined(Base, :Ryu)
+
 @testset "Internals" begin
     @test Showoff.@grisu_ccall(1, 2, 3) === nothing
     if isdefined(Showoff, :Grisu)
@@ -35,23 +37,23 @@ end
     @test Showoff.format_fixed_scientific(NaN, 1, false) == "NaN"
     @test Showoff.format_fixed_scientific(0.012345678, 4, true) == "12.346×10⁻³"
     @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.2346×10⁻²"
-    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
+    @test Showoff.format_fixed_scientific(-10.0, 4, false) == (drops0s ? "-1.000×10¹" : "-1.0000×10¹")
     @test Showoff.format_fixed_scientific(-10.0, 4, true) == "-10.000×10⁰"
-    @test Showoff.format_fixed_scientific(-10.0, 4, false)[1:end-5] == @sprintf("%0.4e", -10.0)[1:end-4]
+    @test Showoff.format_fixed_scientific(-10.0, 4, false)[1:end-5] == (drops0s ? @sprintf("%0.4e", -10.0)[1:end-5] : @sprintf("%0.4e", -10.0)[1:end-4])
     @test Showoff.format_fixed_scientific(1.23456e7, 3, false)[1:end-5] == @sprintf("%0.3e", 1.23456e7)[1:end-4]
-    @test Showoff.format_fixed_scientific(2.99999999999999956E-16, 2, false) == "3.00×10⁻¹⁶"
+    @test Showoff.format_fixed_scientific(2.99999999999999956E-16, 2, false) == (drops0s ? "3.0×10⁻¹⁶" : "3.00×10⁻¹⁶")
 end
 
 @testset "Showoff" begin
     x = [1.12345, 4.5678]
     @test showoff(x) == ["1.12345", "4.56780"]
-    @test showoff([0.0, 50000.0]) == ["0", "5.0×10⁴"]
+    @test showoff([0.0, 50000.0]) == (drops0s ? ["0", "5×10⁴"] : ["0", "5.0×10⁴"])
     @test showoff(x, :plain) == ["1.12345", "4.56780"]
-    @test showoff(x, :scientific) == ["1.123450×10⁰", "4.567800×10⁰"]
-    @test showoff(x, :engineering) == ["1.123450×10⁰", "4.567800×10⁰"]
+    @test showoff(x, :scientific) == (drops0s ? ["1.12345×10⁰", "4.56780×10⁰"] : ["1.123450×10⁰", "4.567800×10⁰"])
+    @test showoff(x, :engineering) == showoff(x, :scientific)
     @test showoff([DateTime("2017-04-11", "yyyy-mm-dd")]) == ["Apr 11, 2017"]
     @test showoff(["a", "b"]) == ["\"a\"", "\"b\""]
-    @test showoff([1, 1e39]) == ["1.0×10⁰", "1.0×10³⁹"]
+    @test showoff([1, 1e39]) == (drops0s ? ["1×10⁰", "1×10³⁹"] : ["1.0×10⁰", "1.0×10³⁹"])
     @test_throws ArgumentError showoff(x, :nevergonnagiveyouup)
     @test showoff([Inf, Inf, NaN]) == ["Inf", "Inf", "NaN"]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ end
     @test Showoff.format_fixed_scientific(0.012345678, 4, true) == "12.346×10⁻³"
     @test Showoff.format_fixed_scientific(0.012345678, 4, false) == "1.2346×10⁻²"
     @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
-    @test Showoff.format_fixed_scientific(-10.0, 4, false) == "-1.0000×10¹"
+    @test Showoff.format_fixed_scientific(-10.0, 4, true) == "-10.000×10⁰"
     @test Showoff.format_fixed_scientific(-10.0, 4, false)[1:end-5] == @sprintf("%0.4e", -10.0)[1:end-4]
     @test Showoff.format_fixed_scientific(1.23456e7, 3, false)[1:end-5] == @sprintf("%0.3e", 1.23456e7)[1:end-4]
     @test Showoff.format_fixed_scientific(2.99999999999999956E-16, 2, false) == "3.00×10⁻¹⁶"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,12 @@
 using Showoff
 using Test
 using Dates
-if isdefined(Base, :Grisu)
-    const Grisu = Base.Grisu
-else
-    import Grisu
-end
 
 @testset "Internals" begin
     @test Showoff.@grisu_ccall(1, 2, 3) === nothing
-    @test Showoff.grisu(1.0, Grisu.SHORTEST, 2) == (1, 1, false, Grisu.DIGITS)
+    if isdefined(Showoff, :Grisu)
+        @test Showoff.grisu(1.0, Showoff.Grisu.SHORTEST, 2) == (1, 1, false, Showoff.Grisu.DIGITS)
+    end
 
     let x = [1.0, Inf, 2.0, NaN]
         @test Showoff.concrete_minimum(x) == 1.0


### PR DESCRIPTION
The main advantage here is latency: using Ryu on supported versions will allow packages to get the advantage of the precompilation we do for Ryu methods. CC @SimonDanisch, @jkrumbiegel (this showed up as one of many sources of Makie's latency; I don't remember exactly how big but I remember being surprised, maybe a second or so?)

Since this package is utterly abandoned, what better time than to go to 1.0? :laughing: 