### PR TITLE
Set version 1.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Showoff"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 author = ["Daniel C. Jones (@dcjones)"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
@isentropic, could you also register a new version after https://github.com/JuliaGraphics/Showoff.jl/pull/41? Gadfly.jl master is currently broken.