### PR TITLE
Switch TagBot to use issue_comment

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,8 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 0 * * *
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
 jobs:
   TagBot:


### PR DESCRIPTION
I noticed that something is off with the TagBot on this repository. Here, I've set the TagBot to use the `issue_comment` which is more robust according to https://github.com/JuliaRegistries/TagBot/issues/125#issuecomment-715473635.