### PR TITLE
Added an option `export_raw` for showoff() to export unprocessed data

### DIFF
--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -80,7 +80,7 @@ function scientific_precision_heuristic(xs::AbstractArray{<:AbstractFloat})
 end
 
 
-function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto)
+function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto; export_raw=false)
     x_min = concrete_minimum(xs)
     x_max = concrete_maximum(xs)
     x_min = Float64(x_min)
@@ -103,11 +103,11 @@ function showoff(xs::AbstractArray{<:AbstractFloat}, style=:auto)
         return String[format_fixed(x, precision) for x in xs]
     elseif style == :scientific
         precision = scientific_precision_heuristic(xs)
-        return String[format_fixed_scientific(x, precision, false)
+        return String[format_fixed_scientific(x, precision, false, export_raw)
                       for x in xs]
     elseif style == :engineering
         precision = scientific_precision_heuristic(xs)
-        return String[format_fixed_scientific(x, precision, true)
+        return String[format_fixed_scientific(x, precision, true, export_raw)
                       for x in xs]
     else
         throw(ArgumentError("$(style) is not a recongnized number format"))

--- a/src/ryu.jl
+++ b/src/ryu.jl
@@ -34,7 +34,7 @@ end
 # Print a floating point number in scientific notation at fixed precision. Sort of equivalent
 # to @sprintf("%0.$(precision)e", x), but prettier printing.
 function format_fixed_scientific(x::AbstractFloat, precision::Integer,
-                                 engineering::Bool)
+                                 engineering::Bool, export_raw::Bool=false)
     if iszero(x)
         return "0"
     elseif isinf(x)
@@ -53,31 +53,35 @@ function format_fixed_scientific(x::AbstractFloat, precision::Integer,
     end
 
 
-    buf = IOBuffer()
+    if export_raw  #if export base_digits and power separately.
+        return e_format_number
+    else
+        buf = IOBuffer()
 
-    print(buf, base_digits)
-    print(buf, "×10")
+        print(buf, base_digits)
+        print(buf, "×10")
 
-    if power[1] == '-'
-        print(buf, '⁻')
-    end
-    leading_index = findfirst(c -> '1' <= c <= '9', power)
-
-    if leading_index === nothing
-        print(buf, superscript_numerals[1])
-        return String(take!(buf))
-    end
-
-    for digit in power[leading_index:end]
-        if digit == '-'
+        if power[1] == '-'
             print(buf, '⁻')
-        elseif '0' <= digit <= '9'
-            print(buf, superscript_numerals[digit - '0' + 1])
+        end
+        leading_index = findfirst(c -> '1' <= c <= '9', power)
+
+        if leading_index === nothing
+            print(buf, superscript_numerals[1])
+            return String(take!(buf))
         end
 
-    end
+        for digit in power[leading_index:end]
+            if digit == '-'
+                print(buf, '⁻')
+            elseif '0' <= digit <= '9'
+                print(buf, superscript_numerals[digit - '0' + 1])
+            end
 
-    return String(take!(buf))
+        end
+
+        return String(take!(buf))
+    end
 end
 
 


### PR DESCRIPTION
In Makie, a new data type `RichText` handles the mathematical representations, e.g., subscript and superscript, for axis labels. This provides an advantage compared with the original returned string by `showoff(::automatic, value)` that the font of the superscripts can be costomised. As I previously mentioned in [a issue of Makie.jl](https://github.com/MakieOrg/Makie.jl/issues/2467) the fonts of basenumbers and powers in axis labels maybe different that can lead to inconsistent visual representation.

My [previous solution](https://github.com/MakieOrg/Makie.jl/pull/4424) was to replace all unicode superscipts back to normal digits for further processing.  While this approach worked, it was not the most elegant solution. To improve this, I propose adding a new option to `showoff()` that allows exporting raw strings. This will enable more flexible and precise handling of text formatting, particularly when working with `RichText`.

Let me know if you’d like further refinements!